### PR TITLE
fix: close nil upstream conn cause panic

### DIFF
--- a/pkg/sshagent/upstream_agent.go
+++ b/pkg/sshagent/upstream_agent.go
@@ -10,11 +10,9 @@ import (
 )
 
 type upstreamAgent struct {
-	conn  net.Conn
-	agent agent.ExtendedAgent
-
+	conn   net.Conn
+	agent  agent.ExtendedAgent
 	socket string
-
 	io.Closer
 }
 
@@ -67,5 +65,8 @@ func (u *upstreamAgent) SignWithFlags(key ssh.PublicKey, data []byte, flags agen
 }
 
 func (u *upstreamAgent) Close() error {
-	return u.conn.Close()
+	if u.conn != nil {
+		return u.conn.Close()
+	}
+	return nil
 }


### PR DESCRIPTION
POC:
```go
package main

import (
	"context"
	"fmt"
	"github.com/oomol-lab/ovm-ssh-agent/pkg/identity"
	"github.com/oomol-lab/ovm-ssh-agent/pkg/sshagent"
	"github.com/oomol-lab/ovm-ssh-agent/pkg/system"
	"net"
	"os"
	"path/filepath"
	"time"
)

func main() {
	ctx, cancel := context.WithCancel(context.Background())

	go func() {
		time.Sleep(5 * time.Second)
                // wait 5 seconds and call cancel() 
		cancel()
	}()

	upstreamSocket := system.GetSSHAgent()
	if upstreamSocket == "" {
		panic("failed to get remote auth socket")
	}

	sshAgent, err := sshagent.NewSSHAgent(ctx, upstreamSocket)
	if err != nil {
		panic(fmt.Errorf("failed to create agent: %w", err))
	}
	defer sshAgent.Close() // this line cause panic

	// find local private keys ~/.ssh
	sshAgent.LoadLocalKeys(identity.FindPrivateKeys()...)

	localSocket := filepath.Join(os.TempDir(), "a.sock")
	_ = os.Remove(localSocket)
	fmt.Printf("start listening: %q", localSocket)
	listener, err := net.Listen("unix", localSocket)
	if err != nil {
		panic(fmt.Errorf("failed to listen unix socket: %w", err))
	}
	defer listener.Close()

	if err := sshAgent.Serve(listener); err != nil {
		fmt.Printf("failed to serve: %v", err)
	}

}

```